### PR TITLE
Feat/fix invalid statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Run the deployment script with your own parameters inserted for `--stack-name`,
 optional `--out-dir`, etc.
 
 ```bash
-curl -s https://raw.githubusercontent.com/elastio/elastio-stack/master/scripts/reds-deploy.sh \
-  | bash -s -- --stack-name <your_company_name_or_username> --out-dir ./elastio-stack
+curl -o ./reds-deploy.sh https://raw.githubusercontent.com/elastio/elastio-stack/master/scripts/reds-deploy.sh
+bash -i ./reds-deploy.sh --stack-name <your_company_name_or_username> --out-dir ./elastio-stack
 ```
 
 `--out-dir` parameter here is optional, but recommended. It allows for saving the initialized
@@ -103,4 +103,4 @@ and run `terraform destroy` from there.
 You might be asked to input some variables (if you haven't set them via `TF_VAR_*` env vars yet):
 - `stack_env` should be set to `prod`.
 - `stack_name` should be set to the identifier you passed as `--stack-name`
-- `aws_region` should be passed explicitly (otherwise it uses current aws profile's region config)
+- `aws_region` should be passed explicitly (otherwise it is `us-east-2` by default)

--- a/scripts/reds-deploy.sh
+++ b/scripts/reds-deploy.sh
@@ -68,6 +68,10 @@ main() {
 
     [ -v aws_region ] || aws_region=$(aws configure get region)
 
+    if [[ -z "$aws_region" ]]; then
+        exit_err 'Could not infer aws region to deploy to. Please configure the aws cli with `aws configure` or pass explicit --aws-region parameter'
+    fi
+
     log_info "Using aws_region: $aws_region"
 
     # Prepare a sandbox on the filesystem where we can save intermediate files


### PR DESCRIPTION
- Add a check for no aws_region or exitsting out-dir
- Split the curl into two lines to allow for interactiveness

Piping to bash seems not to allow for answering questions terraform asks
Fix invalid statement about using aws configure get region (it do is us-east-2 hardcoded due to terrafrom default values limitation)