### PR TITLE
Increase IAM role creation timeout

### DIFF
--- a/.tmuxp.yaml
+++ b/.tmuxp.yaml
@@ -1,0 +1,13 @@
+session_name: elastio-stack
+start_directory: ./
+windows:
+  - window_name: editor
+    focus: true
+    panes:
+        - vim
+  - window_name: rust shell
+    panes:
+        - pane
+  - window_name: misc shell
+    panes:
+        - pane

--- a/scripts/launch-s0-instance.sh
+++ b/scripts/launch-s0-instance.sh
@@ -166,7 +166,7 @@ EOF
     rm -r $trust_policy $role
 
     # Sleep a bit to avoid an error (InvalidParameterValue: Invalid IAM Instance Profile name) when calling the RunInstances operation.
-    sleep 3
+    sleep 10
 }
 
 usage()


### PR DESCRIPTION
3 seconds wasn't long enough in Naj's environment, the new role hadn't propagated by the time he tried to launch the instance.
