### PR TITLE
Allow elastio-snap installation on Fedora 31

### DIFF
--- a/scripts/install-elastio.sh
+++ b/scripts/install-elastio.sh
@@ -182,8 +182,8 @@ case ${dist_name} in
     ;;
 
     fedora | fc )
-        if [ ! -z "$driver" ]; then
-            echo "There are no elastio-snap packages for Fedora (kernel 5.8 and newer) yet. Ignoring driver installation..."
+        if [ ! -z "$driver" ] &&  [ $dist_ver -gt 31 ]; then
+            echo "There are no elastio-snap packages for Fedora 32 and newer (kernel 5.9+) yet. Ignoring driver installation..."
             unset driver
         fi
 


### PR DESCRIPTION
It's allowed since https://github.com/elastio/elastio-snap/issues/44
has been resolved. Now Fedora 32 already has Linux kernel 5.9 and
Fedora 31 has Linux kernel 5.8.