### PR TITLE
Use reds.tar.gz archive with terraform templates from `elastio-aws-lambda-binaries` bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [terraform-download]: https://www.terraform.io/downloads.html
-[red-stack-tar]: http://repo.assur.io/release/reds.tar.gz
+[red-stack-tar]: https://elastio-aws-lambda-binaries.s3.us-east-2.amazonaws.com/prod/reds.tar.gz
 [aws-cli-installation]: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html
 
 # elastio

--- a/scripts/reds-deploy.sh
+++ b/scripts/reds-deploy.sh
@@ -11,7 +11,7 @@ set -eu -o pipefail
 export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 
 reds_tar_name='reds.tar.gz'
-reds_tar_url="http://repo.assur.io/release/${reds_tar_name}"
+reds_tar_url="https://elastio-aws-lambda-binaries.s3.us-east-2.amazonaws.com/prod/${reds_tar_name}"
 # Pinned version of terraform
 tf_version=0.14.3
 


### PR DESCRIPTION
Chaning the distribution bucket and object identifiers as per https://github.com/elastio/elastio/pull/1684