### PR TITLE
Use reds.tar.gz archive with terraform templates from `elastio-aws-lambda-binaries` bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [terraform-download]: https://www.terraform.io/downloads.html
-[red-stack-tar]: http://repo.assur.io/release/reds.tar.gz
+[red-stack-tar]: https://elastio-aws-lambda-binaries.s3.us-east-2.amazonaws.com/prod/reds.tar.gz
 [aws-cli-installation]: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html
 
 # elastio

--- a/scripts/reds-deploy.sh
+++ b/scripts/reds-deploy.sh
@@ -11,7 +11,7 @@ set -eu -o pipefail
 export PS4='+ [${BASH_SOURCE[0]##*/}:${LINENO}${FUNCNAME[0]:+:${FUNCNAME[0]}}] '
 
 reds_tar_name='reds.tar.gz'
-reds_tar_url="http://repo.assur.io/release/${reds_tar_name}"
+reds_tar_url="https://elastio-aws-lambda-binaries.s3.us-east-2.amazonaws.com/prod/${reds_tar_name}"
 # Pinned version of terraform
 tf_version=0.14.3
 


### PR DESCRIPTION
Links to the new release https://github.com/elastio/elastio/actions/runs/601427763
I see our master branch of elastio has some random failing tests (of filesystem generation I guess?), so I've manually run a release on my host and uploaded the artifacts just like the ci job does, so this should be ready to use even if the ci release job fails.
You can press the merge button here basically anytime @anelson