### PR TITLE
Display error when no region is configured

### DIFF
--- a/scripts/reds-deploy.sh
+++ b/scripts/reds-deploy.sh
@@ -66,7 +66,7 @@ main() {
         exit 2
     fi
 
-    [ -v aws_region ] || aws_region=$(aws configure get region || echo '')
+    [ -v aws_region ] || aws_region=$(aws configure get region || true)
 
     if [[ -z "$aws_region" ]]; then
         exit_err 'Could not infer aws region to deploy to. Please configure the aws cli with `aws configure` or pass explicit --aws-region parameter'

--- a/scripts/reds-deploy.sh
+++ b/scripts/reds-deploy.sh
@@ -66,7 +66,7 @@ main() {
         exit 2
     fi
 
-    [ -v aws_region ] || aws_region=$(aws configure get region)
+    [ -v aws_region ] || aws_region=$(aws configure get region || echo '')
 
     if [[ -z "$aws_region" ]]; then
         exit_err 'Could not infer aws region to deploy to. Please configure the aws cli with `aws configure` or pass explicit --aws-region parameter'


### PR DESCRIPTION
Closes https://github.com/elastio/elastio/issues/1601

When the region is not configured, `aws configure get region` exits with no output and status `1`. This seems to exit from our script early, so added a `|| true` to circumvent that

Manually verified it works on a bare ec2 instance with cli not configured