### PR TITLE
Fix uninstall/install Elastio packages on RPM-based systems

### DIFF
--- a/scripts/install-elastio.sh
+++ b/scripts/install-elastio.sh
@@ -85,7 +85,11 @@ uninstall_all()
     if which apt-get >/dev/null 2>&1; then
         dpkg -l | grep elastio | awk '{ print $2}' | xargs apt-get remove --purge -y
     else
-        rpm -qa | grep elastio | xargs yum remove -y
+        rpm -qa | grep elastio | grep -v elastio-repo | xargs yum remove -y
+        yum clean all --disablerepo="*" --enablerepo=Elastio
+        yum remove -y elastio-repo
+        # Remove cache (mirror files) in case if no elastio packages remain for sure
+        rpm -qa | grep -q elastio || rm -rf /var/cache/yum/*/*/Elastio/
     fi
 }
 


### PR DESCRIPTION
There was an issue on CentOS / Amazon Linux when release packages are
installed and then uninstalled. And dev packages are installed with the
script param `-b master` but still release packages appeared in the
system. The issue was in the remaining files in the
/var/cache/yum/x86_64/2/Elastio/ after uninstall. The files repomd.xml
and mirrors.txt preserved link to the previously used repository.
Fixed this issue.