### PR TITLE
Adjust the packages removal algorithm and add Fedora 35

### DIFF
--- a/scripts/install-elastio.sh
+++ b/scripts/install-elastio.sh
@@ -231,9 +231,9 @@ case ${dist_name} in
         fi
 
         case ${dist_ver} in
-            31 | 32 | 33 | 34 ) cent_fedora_install Fedora $(rpm -E %fedora) fc ;;
+            31 | 34 | 35 ) cent_fedora_install Fedora $(rpm -E %fedora) fc ;;
             * )
-                echo "Fedora versions 31-34 are supported. Current distro version $dist_ver isn't supported."
+                echo "Fedora versions 31 and 34, 35 are supported. Current distro version $dist_ver isn't supported."
                 exit 1
             ;;
         esac


### PR DESCRIPTION
1) Avoid unintentional uninstall of any `*elastio*` but not Elastio's package.
  Resolves https://github.com/elastio/elastio/issues/4032

2) Add Fedora 35 and remove Fedora 32, 33.