### PR TITLE
iscan: Don't mention ISCAN_EXTRA_PARAMS in the help message

### DIFF
--- a/scripts/iscan
+++ b/scripts/iscan
@@ -44,9 +44,8 @@ Positional arguments:
   <volume>    Path to a directory, path to a block device, or ID of Elastio recovery point
 
 Environment variables:
-  S3_BUCKET           S3 bucket to upload scan results to (default: '$DEFAULT_S3_BUCKET').
-                      Setting S3_BUCKET to an empty string disables S3 upload.
-  ISCAN_EXTRA_PARAMS  Extra options for ransomware detection for developers.
+  S3_BUCKET   S3 bucket to upload scan results to (default: '$DEFAULT_S3_BUCKET').
+              Setting S3_BUCKET to an empty string disables S3 upload.
 EOF
 }
 
@@ -243,12 +242,10 @@ cmd_scan() {
     # XXX TODO: If $out exists, ask the user if it's OK to overwrite it.
     trap "rm -f $out" 0
 
-    # NOTE: `iscan` Docker image doesn't require BD_* variables to be set.
-    # We provide the opportunity to set them, but leave it intentionally undocumented
-    # (i.e., BD_* variables are not mentioned in the `--help` output).
-    local env_bitdefender=
-    env_bitdefender+=" ${BD_LICENSE:+--env BD_LICENSE=$BD_LICENSE}"
-    env_bitdefender+=" ${BD_UPDATES_SERVER:+--env BD_UPDATES_SERVER=$BD_UPDATES_SERVER}"
+    # We provide the opportunity to set ISCAN_EXTRA_PARAMS variable, but leave it
+    # intentionally undocumented (i.e., not mentioned in the `--help` output).
+    local env_extra=
+    env_extra+=${ISCAN_EXTRA_PARAMS:+--env ISCAN_EXTRA_PARAMS="$ISCAN_EXTRA_PARAMS"}
 
     # Scan the volume
     #
@@ -257,17 +254,15 @@ cmd_scan() {
         $DOCKER run --rm \
             --mount readonly,type=bind,source="$volume",destination=/vol \
             --env STEM="$name" \
-            $env_bitdefender \
-            $image --for $opt_for \
-            ${ISCAN_EXTRA_PARAMS:+-e ISCAN_EXTRA_PARAMS="$ISCAN_EXTRA_PARAMS"} \
-            /vol
+            $env_extra \
+            $image \
+            --for $opt_for /vol
     elif [[ -b "$volume" ]]; then
         $DOCKER run --rm --privileged \
             --env STEM="$name" \
-            $env_bitdefender \
-            $image --for $opt_for \
-            ${ISCAN_EXTRA_PARAMS:+-e ISCAN_EXTRA_PARAMS="$ISCAN_EXTRA_PARAMS"} \
-            "$volume"
+            $env_extra \
+            $image \
+            --for $opt_for "$volume"
     elif [[ "$volume" =~ ^r-[a-z0-9]{24}$ ]]; then
         # - AWS credentials are needed to run `elastio mount` from within docker.
         # - /lib/modules are required to `insmod nbd`.
@@ -277,10 +272,9 @@ cmd_scan() {
             -v /lib/modules:/lib/modules:ro \
             -v /dev:/dev \
             --env STEM="$name" \
-            $env_bitdefender \
-            $image --for $opt_for
-            ${ISCAN_EXTRA_PARAMS:+-e ISCAN_EXTRA_PARAMS="$ISCAN_EXTRA_PARAMS"} \
-            "$volume"
+            $env_extra \
+            $image \
+            --for $opt_for "$volume"
     else
         die "$volume is neither a directory, nor a block device, nor a recovery point ID"
     fi |


### PR DESCRIPTION
+ Delete obsolete Bitdefender envvars.