### PR TITLE
iscan: Support relative path to directory

### DIFF
--- a/scripts/iscan
+++ b/scripts/iscan
@@ -252,7 +252,7 @@ cmd_scan() {
     # soon.
     if [[ -d "$volume" ]]; then
         $DOCKER run --rm \
-            --mount readonly,type=bind,source="$volume",destination=/vol \
+            --mount readonly,type=bind,source="$(readlink -f $volume)",destination=/vol \
             --env STEM="$name" \
             $image \
             --for $opt_for \


### PR DESCRIPTION
Before:
```
$ S3_BUCKET= iscan . || echo FAIL $?
latest: Pulling from elastio-dev/iscan
Digest: sha256:13dc65ac96dc52e786413b39ec08a83805928b19602030a054ffa3376e5b735c
Status: Image is up to date for public.ecr.aws/elastio-dev/iscan:latest
public.ecr.aws/elastio-dev/iscan:latest
docker: Error response from daemon: invalid mount config for type "bind": invalid mount path: '.' mount path must be absolute.
See 'docker run --help'.
FAIL 125
```

After:
```
$ S3_BUCKET= iscan . || echo FAIL $?
latest: Pulling from elastio-dev/iscan
Digest: sha256:13dc65ac96dc52e786413b39ec08a83805928b19602030a054ffa3376e5b735c
Status: Image is up to date for public.ecr.aws/elastio-dev/iscan:latest
public.ecr.aws/elastio-dev/iscan:latest
{"timestamp":"2021-11-24T21:33:18.449269134+00:00","level":"INFO","line":273,"file":"iscan-malware/src/main.rs","fields":{"message":"Waiting for server to start..."},"target":"console","thread_id":"ThreadId(1)"}
{"timestamp":"2021-11-24T21:33:22.636492994+00:00","level":"INFO","line":275,"file":"iscan-malware/src/main.rs","fields":{"message":"Server started, scanning..."},"target":"console","thread_id":"ThreadId(1)"}
 done
Results saved to /tmp/iscan-elab--211124-213314.tar.gz
```