### PR TITLE
iscan: Don't strip dashes from recovery point IDs

### DIFF
--- a/scripts/iscan
+++ b/scripts/iscan
@@ -222,7 +222,7 @@ cmd_scan() {
         #
         # The purpose of the `tr`-ickery below is to remove colons, backslashes,
         # and other nonsence symbols from Windows paths.
-        name=$(basename "$volume" | tr -dc '[:alnum:]')
+        name=$(basename "$volume" | tr -dc '[:alnum:]-')
         name="iscan-$HOSTNAME-$name-$(date --utc +%y%m%d-%H%M%S)"
     fi
 


### PR DESCRIPTION
Before:
```
iscan-ip-172-31-29-149-rdgj1it8cpdx9tdm9m9dewud4-211123-150704.tar.gz
```

After:
```
iscan-ip-172-31-29-149-r-dgj1it8cpdx9tdm9m9dewud4-211123-150704.tar.gz
```

Recovery point IDs are more recognizable this way.