### PR TITLE
Install NBD on AL2

### DIFF
--- a/scripts/install-elastio.sh
+++ b/scripts/install-elastio.sh
@@ -49,6 +49,9 @@ cent_fedora_install()
 {
     if [ "$1" = "CentOS" ] && grep "Red Hat" -q /etc/redhat-release 2>/dev/null ; then
         yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-$2.noarch.rpm
+    elif [ "$1" = "Amazon" ]; then
+        amazon-linux-extras install -y epel
+        yum install -y nbd
     fi
 
     # The elastio-repo package is going to be moved from the x86_64/Packages to the noarch/Packages


### PR DESCRIPTION
AL2 has `nbd` kernel module but doesn't have `nbd-client`. It can be
installed from the `epel` repo as `nbd` package. But this repo is not
available for yum as on CentOS. And, as result, `nbd` package can't be
added as dependency for the `elastio` package on AL2.
That's why using AL2's way to enable `epel` via their internal command
and installing `nbd` package manually.
As result, the `nbd-client` version 3.14 is installed.

Resolves part 2 of https://github.com/elastio/elastio/issues/4295