### PR TITLE
Allow to install elastio-snap on machine with Linux 5.18

### DIFF
--- a/scripts/install-elastio.sh
+++ b/scripts/install-elastio.sh
@@ -4,7 +4,7 @@ me="./install-elastio.sh"
 default_branch=release
 
 MAX_LINUX_VER=5
-MAX_LINUX_MAJOR_REV=17
+MAX_LINUX_MAJOR_REV=18
 
 cent_fedora_kernel_devel_install()
 {


### PR DESCRIPTION
The new Elastio release contains an update for elastio-snap with support
of the Linux kernel version 5.18. This kernel version is now the default
on Fedora 36.