### PR TITLE
Install nbd explicitly

### DIFF
--- a/scripts/install-elastio.sh
+++ b/scripts/install-elastio.sh
@@ -93,6 +93,8 @@ cent_fedora_install()
 
     # Install ntfs-3g to any RPM-based distro except Fedora 35+ with the kernel 5.15+
     [ $2 -lt 35 ] && yum install -y ntfs-3g
+    # Install nbd to any RPM-based distro except Amazon Linux 2 and 2023
+    [ "$1" != "Amazon" ] && yum install -y nbd
 }
 
 check_installed()
@@ -152,7 +154,7 @@ deb_ubu_install()
         apt-get -o apt::install-recommends=true install -y elastio-snap-utils
     elif [ ! -z "$cli" ]; then
         # Install just elastio w/o driver as dependency
-        apt-get --no-install-recommends install -y elastio ntfs-3g
+        apt-get --no-install-recommends install -y elastio ntfs-3g nbd-client
     fi
 }
 
@@ -329,10 +331,9 @@ case ${dist_name} in
 
     fedora | fc )
         case ${dist_ver}-$(uname -m) in
-            38-*      ) cent_fedora_install Fedora $(rpm -E %fedora) fc ;;
-            39-*      ) cent_fedora_install Fedora $(rpm -E %fedora) fc ;;
-            *  )
-                echo "Only Fedora versions 38 and 39 are supported. Current distro version $dist_ver isn't supported."
+            39-* | 40-* ) cent_fedora_install Fedora $(rpm -E %fedora) fc ;;
+            * )
+                echo "Only Fedora versions 39 and 40 are supported. Current distro version $dist_ver isn't supported."
                 exit 1
             ;;
         esac


### PR DESCRIPTION
This pull request includes changes to the installation scripts for CentOS, Fedora, and Debian/Ubuntu systems to ensure the necessary packages are installed. The most important changes include adding the `nbd` package to the CentOS/Fedora installation and the `nbd-client` package to the Debian/Ubuntu installation.

Package additions:

* [`scripts/install-elastio.sh`](diffhunk://#diff-140ec7e3534c5f069e64278e6e34535630189b72153533b35375b20dd166f5ceR68): Added `yum install -y nbd` to the `cent_fedora_install()` function to ensure the `nbd` package is installed on CentOS and Fedora systems.
* [`scripts/install-elastio.sh`](diffhunk://#diff-140ec7e3534c5f069e64278e6e34535630189b72153533b35375b20dd166f5ceL155-R156): Added `apt-get --no-install-recommends install -y elastio ntfs-3g nbd-client` to the `deb_ubu_install()` function to ensure the `nbd-client` package is installed on Debian and Ubuntu systems.

Resolves https://github.com/elastio/elastio/issues/9765