### PR TITLE
ci: add collect-modules action

### DIFF
--- a/.github/actions/collect-modules/action.yaml
+++ b/.github/actions/collect-modules/action.yaml
@@ -1,0 +1,33 @@
+name: Find modules in the repository
+description: >
+  Looks for modules in the repository and outputs their paths.
+
+outputs:
+  tf-modules:
+    description: Paths to the Terraform modules found in the repository
+    value: ${{ steps.find-modules.outputs.tf-modules }}
+
+runs:
+  using: composite
+  steps:
+    - name: Find modules
+      id: find-modules
+      run: |
+        set -eu
+
+        tf_modules=()
+        for module_cfg in $(find . -name .module.toml); do
+          case $(yq -o y .module.type $module_cfg) in
+            null)
+              echo "Warning:  module type not found in $module_cfg"
+              continue
+              ;;
+            terraform)
+              echo "Found Terraform module in $module_cfg"
+              tf_modules+=($(dirname $module_cfg))
+              ;;
+          esac
+        done
+
+        echo tf-modules=$(printf '%s\n' "${tf_modules[@]}" | jq -cnR '[inputs]') > $GITHUB_OUTPUT
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,17 @@ on:
   pull_request:
 
 jobs:
+  collect-modules:
+    runs-on: ubuntu-latest
+    outputs:
+      tf-modules: ${{ steps.collect-modules.outputs.tf-modules }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/collect-modules
+        id: collect-modules
+
   typos:
     runs-on: ubuntu-latest
     steps:
@@ -49,11 +60,12 @@ jobs:
 
   terraform-docs:
     runs-on: ubuntu-latest
+    needs:
+      - collect-modules
 
     strategy:
       matrix:
-        terraform_module:
-          - asset-account/terraform/stack-set
+        terraform_module: ${{fromJson(needs.collect-modules.outputs.tf-modules)}}
 
     steps:
       - uses: actions/checkout@v4

--- a/asset-account/terraform/stack-set/.module.toml
+++ b/asset-account/terraform/stack-set/.module.toml
@@ -1,0 +1,5 @@
+[module]
+name = "aws-elastio-asset-account-stack-set"
+description = "Terraform module for creating an asset account stack"
+type = "terraform"
+version = "0.33.0"


### PR DESCRIPTION
This pull request includes several changes to automate the collection of Terraform modules and update configuration files. The most important changes include adding a custom GitHub action to find Terraform modules, modifying the CI workflow to use this action, and updating configuration files.

**Automation of Terraform module collection:**

* Added a custom GitHub action in `.github/actions/collect-modules/action.yaml` to find Terraform modules in the repository and output their paths.
* Updated the CI workflow in `.github/workflows/ci.yml` to include a new job `collect-modules` that uses the custom action to find Terraform modules and outputs their paths.
* Modified the `terraform-docs` job in `.github/workflows/ci.yml` to depend on the `collect-modules` job and use the collected module paths.

**Configuration file updates:**

* Added default and profile-based configuration settings in `asset-account/terraform/config.ini`.
* Added default and profile-based credentials in `asset-account/terraform/credentials.ini`.
* Created a `.module.toml` file in `asset-account/terraform/stack-set` to define the module type and metadata.