### PR TITLE
Add missing `kms` permissions to ElastioAssetAccountDeployer

### DIFF
--- a/asset-account/terraform/cloudformation-stack/examples/advanced/.terraform.lock.hcl
+++ b/asset-account/terraform/cloudformation-stack/examples/advanced/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.92.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:ZnpTxMfg5PThZc5WZCsZELinsR0gPhdTpNmXjVcf7aE=",
+    "zh:1d3a0b40831360e8e988aee74a9ff3d69d95cb541c2eae5cb843c64303a091ba",
+    "zh:3d29cbced6c708be2041a708d25c7c0fc22d09e4d0b174360ed113bfae786137",
+    "zh:4341a203cf5820a0ca18bb514ae10a6c113bc6a728fb432acbf817d232e8eff4",
+    "zh:4a49e2d91e4d92b6b93ccbcbdcfa2d67935ce62e33b939656766bb81b3fd9a2c",
+    "zh:54c7189358b37fd895dedbabf84e509c1980a8c404a1ee5b29b06e40497b8655",
+    "zh:5d8bb1ff089c37cb65c83b4647f1981fded993e87d8132915d92d79f29e2fcd8",
+    "zh:618f2eb87cd65b245aefba03991ad714a51ff3b841016ef68e2da2b85d0b2325",
+    "zh:7bce07bc542d0588ca42bac5098dd4f8af715417cd30166b4fb97cedd44ab109",
+    "zh:81419eab2d8810beb114b1ff5cbb592d21edc21b809dc12bb066e4b88fdd184a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9dea39d4748eeeebe2e76ca59bca4ccd161c2687050878c47289a98407a23372",
+    "zh:d692fc33b67ac89e916c8f9233d39eacab8c438fe10172990ee9d94fba5ca372",
+    "zh:d9075c7da48947c029ba47d5985e1e8e3bf92367bfee8ca1ff0e747765e779a1",
+    "zh:e81c62db317f3b640b2e04eba0ada8aa606bcbae0152c09f6242e86b86ef5889",
+    "zh:f68562e073722c378d2f3529eb80ad463f12c44aa5523d558ae3b69f4de5ca1f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.13.0"
+  constraints = "~> 0.13"
+  hashes = [
+    "h1:W2XSd8unrfQsFLBCqtOZf8GywZTU7FOgAI95YmIwxQw=",
+    "zh:3776dd78ef3053562ccb2f8916d5d3f21a28f05e78859f0f1e4510525f891ecb",
+    "zh:541ca0b56f808c15d208b9396f149563b133223c4b66cdefbcfe2d8f1c23497e",
+    "zh:67ed315f3572eb20ce6778423b14fbb6faba3090f454bc20ec4146489b4738c0",
+    "zh:69dc375845bcfc451426480119f2941ee28b9ef01273d228bb66918180863b3a",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:93c24b7c87b5db9721f60782ac784152599aa78b30fdea2fc9c594d46d92767c",
+    "zh:95441cf14312041ae0b34640ff33975c09540125b01f9131358fca50e7be239d",
+    "zh:a294103aeed868c58987e131357a3ec259316c937c909e8a726b862d5a227b82",
+    "zh:adf6ded3f2e2f318e8aebf1040bc2791b448d006af7d12f7ddc3e8d40b22047a",
+    "zh:b2d9c16b7acd20d3813060c4d3647dc5f40598ebbdf59f642d53d189e4e3870a",
+    "zh:bc76a5161e9bcf74cadd76b3d4a51de508aa0c62e7f7ae536a87cd7595d81ebf",
+    "zh:ce6df2c1052c60b4432cb5c0ead471d7cdb4b285b807c265328a358631fc3610",
+  ]
+}

--- a/asset-account/terraform/cloudformation-stack/examples/advanced/main.tf
+++ b/asset-account/terraform/cloudformation-stack/examples/advanced/main.tf
@@ -1,0 +1,48 @@
+module "elastio_asset_account" {
+  source = "../../"
+
+  stack_name = "ElastioAssetAccount2"
+
+  template_url     = var.template_url
+  encrypt_with_cmk = true
+  iam_role_arn     = time_sleep.iam.triggers.deployer_role_arn
+}
+
+resource "aws_iam_role" "deployer" {
+  name = "ElastioAssetAccountDeployer"
+  assume_role_policy = jsonencode(
+    {
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Effect" : "Allow"
+          "Principal" : {
+            "Service" : "cloudformation.amazonaws.com"
+          }
+          "Action" : "sts:AssumeRole"
+        }
+      ]
+    }
+  )
+}
+
+resource "aws_iam_role_policy_attachment" "elastio_asset_account_deployer" {
+  role       = aws_iam_role.deployer.name
+  policy_arn = module.elastio_policies.policies.ElastioAssetAccountDeployer.arn
+}
+
+module "elastio_policies" {
+  source   = "../../../../../iam-policies/terraform"
+  policies = ["ElastioAssetAccountDeployer"]
+}
+
+# Wait for the IAM role and policies to propagate
+resource "time_sleep" "iam" {
+  create_duration = "20s"
+
+  depends_on = [aws_iam_role_policy_attachment.elastio_asset_account_deployer]
+
+  triggers = {
+    deployer_role_arn = aws_iam_role.deployer.arn
+  }
+}

--- a/asset-account/terraform/cloudformation-stack/examples/advanced/main.tf
+++ b/asset-account/terraform/cloudformation-stack/examples/advanced/main.tf
@@ -15,10 +15,10 @@ resource "aws_iam_role" "deployer" {
       "Version" : "2012-10-17",
       "Statement" : [
         {
-          "Effect" : "Allow"
+          "Effect" : "Allow",
           "Principal" : {
             "Service" : "cloudformation.amazonaws.com"
-          }
+          },
           "Action" : "sts:AssumeRole"
         }
       ]

--- a/asset-account/terraform/cloudformation-stack/examples/advanced/main.tf
+++ b/asset-account/terraform/cloudformation-stack/examples/advanced/main.tf
@@ -1,8 +1,6 @@
 module "elastio_asset_account" {
   source = "../../"
 
-  stack_name = "ElastioAssetAccount2"
-
   template_url     = var.template_url
   encrypt_with_cmk = true
   iam_role_arn     = time_sleep.iam.triggers.deployer_role_arn

--- a/asset-account/terraform/cloudformation-stack/examples/advanced/variables.tf
+++ b/asset-account/terraform/cloudformation-stack/examples/advanced/variables.tf
@@ -1,0 +1,13 @@
+variable "template_url" {
+  description = <<-DESCR
+    The URL of the Elastio Asset Account CloudFormation template obtained from
+    the Elastio Portal.
+
+    This parameter is sensitive, because anyone who knows this URL can deploy
+    Elastio Account stack and linking it to your Elastio tenant.
+  DESCR
+
+  sensitive = true
+  type      = string
+  nullable  = false
+}

--- a/asset-account/terraform/cloudformation-stack/examples/advanced/versions.tf
+++ b/asset-account/terraform/cloudformation-stack/examples/advanced/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.13"
+    }
+  }
+}

--- a/codegen/src/policies/ElastioAssetAccountDeployer.ts
+++ b/codegen/src/policies/ElastioAssetAccountDeployer.ts
@@ -16,7 +16,7 @@ export default {
   description: "Permissions required to deploy the Elastio Asset Account stack",
   statements: [
     {
-      Action: ["lambda:*", "cloudformation:*", "logs:*", "ssm:*"],
+      Action: ["lambda:*", "cloudformation:*", "logs:*", "ssm:*", "kms:*"],
       Resource: "*",
     },
     {

--- a/iam-policies/terraform/.module.toml
+++ b/iam-policies/terraform/.module.toml
@@ -2,4 +2,4 @@
 name = "aws-elastio-iam-policies"
 description = "A collection of AWS IAM policies for use with Elastio"
 type = "terraform"
-version = "0.33.1"
+version = "0.33.2"

--- a/iam-policies/terraform/README.md
+++ b/iam-policies/terraform/README.md
@@ -9,7 +9,7 @@ This Terraform module deploys additional Elastio IAM managed policies that you c
 ```tf
 module "elastio_policies" {
   source  = "terraform.cloudsmith.io/public/elastio-iam-policies/aws"
-  version = "0.33.1"
+  version = "0.33.2"
 
   // Provide input parameters
 }

--- a/iam-policies/terraform/policies/ElastioAssetAccountDeployer.json
+++ b/iam-policies/terraform/policies/ElastioAssetAccountDeployer.json
@@ -4,7 +4,7 @@
     "Version": "2012-10-17",
     "Statement": [
       {
-        "Action": ["lambda:*", "cloudformation:*", "logs:*", "ssm:*"],
+        "Action": ["lambda:*", "cloudformation:*", "logs:*", "ssm:*", "kms:*"],
         "Resource": "*",
         "Effect": "Allow"
       },

--- a/iam-policies/terraform/policies/ElastioAssetAccountDeployer.json
+++ b/iam-policies/terraform/policies/ElastioAssetAccountDeployer.json
@@ -4,7 +4,7 @@
     "Version": "2012-10-17",
     "Statement": [
       {
-        "Action": ["lambda:*", "cloudformation:*", "logs:*", "ssm:*", "kms:*"],
+        "Action": ["lambda:*", "cloudformation:*", "logs:*", "ssm:*"],
         "Resource": "*",
         "Effect": "Allow"
       },
@@ -77,6 +77,65 @@
         "Sid": "ElastioIamPassRole",
         "Action": "iam:PassRole",
         "Resource": ["arn:*:iam::*:role/*Elastio*"],
+        "Effect": "Allow"
+      },
+      {
+        "Sid": "ElastioKmsRead",
+        "Action": [
+          "kms:DescribeKey",
+          "kms:GetKeyPolicy",
+          "kms:GetKeyRotationStatus",
+          "kms:ListResourceTags"
+        ],
+        "Resource": "*",
+        "Effect": "Allow"
+      },
+      {
+        "Sid": "ElastioKmsCreate",
+        "Action": ["kms:CreateKey"],
+        "Resource": "*",
+        "Condition": {
+          "StringLike": {
+            "aws:RequestTag/elastio:resource": "*"
+          }
+        },
+        "Effect": "Allow"
+      },
+      {
+        "Sid": "ElastioKmsWrite",
+        "Action": [
+          "kms:PutKeyPolicy",
+          "kms:ScheduleKeyDeletion",
+          "kms:EnableKeyRotation",
+          "kms:DisableKeyRotation",
+          "kms:TagResource",
+          "kms:UntagResource",
+          "kms:Decrypt",
+          "kms:Encrypt",
+          "kms:GenerateDataKey",
+          "kms:CreateGrant"
+        ],
+        "Resource": "*",
+        "Condition": {
+          "StringLike": {
+            "aws:ResourceTag/elastio:resource": "*"
+          }
+        },
+        "Effect": "Allow"
+      },
+      {
+        "Action": ["kms:CreateAlias", "kms:DeleteAlias", "kms:UpdateAlias"],
+        "Resource": ["arn:aws:kms:*:*:alias/elastio-*"],
+        "Effect": "Allow"
+      },
+      {
+        "Action": ["kms:CreateAlias", "kms:DeleteAlias", "kms:UpdateAlias"],
+        "Resource": ["arn:aws:kms:*:*:key/*"],
+        "Condition": {
+          "StringLike": {
+            "aws:ResourceTag/elastio:resource": "*"
+          }
+        },
         "Effect": "Allow"
       }
     ]


### PR DESCRIPTION
I forgot to add `kms` permissions to the deployer role, which are required if `encryptWithCmk` is enabled.