### PR TITLE
feat: enable Fedora 41 and Fedora 42 support

### DIFF
--- a/scripts/install-elastio.sh
+++ b/scripts/install-elastio.sh
@@ -86,7 +86,7 @@ cent_fedora_install()
     done
 
     rpm --import https://$repo_host/GPG-KEY-elastio
-    yum localinstall -y $repo_package_url
+    yum install -y $repo_package_url
     which dnf >/dev/null 2>&1 &&
         cent8_fedora_install $1 $2 $3 ||
         cent7_amazon_install $1 $2 $3
@@ -331,7 +331,7 @@ case ${dist_name} in
 
     fedora | fc )
         case ${dist_ver}-$(uname -m) in
-            39-* | 40-* ) cent_fedora_install Fedora $(rpm -E %fedora) fc ;;
+            40-* | 41-* | 42-* ) cent_fedora_install Fedora $(rpm -E %fedora) fc ;;
             * )
                 echo "Only Fedora versions 39 and 40 are supported. Current distro version $dist_ver isn't supported."
                 exit 1


### PR DESCRIPTION
This pull request updates the Fedora version support in the `scripts/install-elastio.sh` script. The change ensures compatibility with newer Fedora versions while maintaining clear error messaging for unsupported versions.

### Fedora version support updates:
* Modified the supported Fedora versions in the `case ${dist_ver}-$(uname -m)` block to include versions 41 and 42, in addition to version 40.