### PR TITLE
Add a migration for CFN stack in Connector stack

### DIFF
--- a/connector/terraform/migrations.tf
+++ b/connector/terraform/migrations.tf
@@ -1,0 +1,4 @@
+moved {
+  from = aws_cloudformation_stack.elastio_account_level_stack
+  to   = module.account.aws_cloudformation_stack.this
+}


### PR DESCRIPTION
Older version of this module from the elastio/contrib repo was using a different CFN stack resource path. Added a `move` block to make it seamless when moving to the new stack version