### PR TITLE
Bump TF version requirements to 1.9 at minimum

### DIFF
--- a/asset-account/terraform/cloudformation-stack/README.md
+++ b/asset-account/terraform/cloudformation-stack/README.md
@@ -25,7 +25,7 @@ module "elastio_asset_account" {
 
 | Name                                                                     | Version |
 | ------------------------------------------------------------------------ | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | ~> 1.0  |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | ~> 1.9  |
 | <a name="requirement_aws"></a> [aws](#requirement_aws)                   | ~> 5.0  |
 
 ## Providers

--- a/asset-account/terraform/cloudformation-stack/examples/advanced/versions.tf
+++ b/asset-account/terraform/cloudformation-stack/examples/advanced/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.9"
 
   required_providers {
     aws = {

--- a/asset-account/terraform/cloudformation-stack/examples/basic/versions.tf
+++ b/asset-account/terraform/cloudformation-stack/examples/basic/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.9"
 }

--- a/asset-account/terraform/cloudformation-stack/versions.tf
+++ b/asset-account/terraform/cloudformation-stack/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.9"
 
   required_providers {
     aws = {

--- a/asset-account/terraform/stack-set/README.md
+++ b/asset-account/terraform/stack-set/README.md
@@ -28,7 +28,7 @@ module "elastio_asset_account" {
 
 | Name                                                                     | Version |
 | ------------------------------------------------------------------------ | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | ~> 1.0  |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | ~> 1.9  |
 | <a name="requirement_aws"></a> [aws](#requirement_aws)                   | ~> 5.0  |
 
 ## Providers

--- a/asset-account/terraform/stack-set/examples/self-managed/versions.tf
+++ b/asset-account/terraform/stack-set/examples/self-managed/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.9"
 
   required_providers {
     aws = {

--- a/asset-account/terraform/stack-set/examples/service-managed/versions.tf
+++ b/asset-account/terraform/stack-set/examples/service-managed/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.9"
 }

--- a/asset-account/terraform/stack-set/versions.tf
+++ b/asset-account/terraform/stack-set/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.9"
 
   required_providers {
     aws = {

--- a/connector/terraform/README.md
+++ b/connector/terraform/README.md
@@ -84,7 +84,7 @@ See [`modules/nat-provision`](./modules/nat-provision) directory for details.
 
 | Name                                                                     | Version |
 | ------------------------------------------------------------------------ | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | ~> 1.0  |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | ~> 1.9  |
 | <a name="requirement_aws"></a> [aws](#requirement_aws)                   | ~> 5.0  |
 | <a name="requirement_http"></a> [http](#requirement_http)                | ~> 3.0  |
 

--- a/connector/terraform/examples/advanced/versions.tf
+++ b/connector/terraform/examples/advanced/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.9"
 }

--- a/connector/terraform/examples/basic/versions.tf
+++ b/connector/terraform/examples/basic/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.9"
 }

--- a/connector/terraform/modules/account/README.md
+++ b/connector/terraform/modules/account/README.md
@@ -23,7 +23,7 @@ module "elastio_connector_account" {
 
 | Name                                                                     | Version |
 | ------------------------------------------------------------------------ | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | ~> 1.0  |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | ~> 1.9  |
 | <a name="requirement_aws"></a> [aws](#requirement_aws)                   | ~> 5.0  |
 | <a name="requirement_http"></a> [http](#requirement_http)                | ~> 3.0  |
 

--- a/connector/terraform/modules/account/versions.tf
+++ b/connector/terraform/modules/account/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.9"
 
   required_providers {
     aws = {

--- a/connector/terraform/modules/nat-provision/README.md
+++ b/connector/terraform/modules/nat-provision/README.md
@@ -23,7 +23,7 @@ module "elastio_nat_provision" {
 
 | Name                                                                     | Version |
 | ------------------------------------------------------------------------ | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | ~> 1.0  |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | ~> 1.9  |
 | <a name="requirement_aws"></a> [aws](#requirement_aws)                   | ~> 5.0  |
 
 ## Providers

--- a/connector/terraform/modules/nat-provision/versions.tf
+++ b/connector/terraform/modules/nat-provision/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.9"
 
   required_providers {
     aws = {

--- a/connector/terraform/modules/region/README.md
+++ b/connector/terraform/modules/region/README.md
@@ -23,7 +23,7 @@ module "elastio_connector_region" {
 
 | Name                                                                     | Version |
 | ------------------------------------------------------------------------ | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | ~> 1.0  |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | ~> 1.9  |
 | <a name="requirement_aws"></a> [aws](#requirement_aws)                   | ~> 5.0  |
 
 ## Providers

--- a/connector/terraform/modules/region/versions.tf
+++ b/connector/terraform/modules/region/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.9"
 
   required_providers {
     aws = {

--- a/connector/terraform/versions.tf
+++ b/connector/terraform/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.9"
 
   required_providers {
     # It's used by child modules

--- a/iam-policies/terraform/README.md
+++ b/iam-policies/terraform/README.md
@@ -41,7 +41,7 @@ See the basic [usage example](./examples/basic/main.tf).
 
 | Name                                                                     | Version |
 | ------------------------------------------------------------------------ | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | ~> 1.0  |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | ~> 1.9  |
 | <a name="requirement_aws"></a> [aws](#requirement_aws)                   | ~> 5.0  |
 
 ## Providers

--- a/iam-policies/terraform/examples/basic/versions.tf
+++ b/iam-policies/terraform/examples/basic/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.9"
 }

--- a/iam-policies/terraform/versions.tf
+++ b/iam-policies/terraform/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.9"
 
   required_providers {
     aws = {


### PR DESCRIPTION
Faced this with one of our users. They were using the TF version 1.5 which doesn't support the "Cross-object referencing for input variable validations" feature of [terraform 1.9](https://www.hashicorp.com/en/blog/terraform-1-9-enhances-input-variable-validations), which is used in various places across our tf modules