### PR TITLE
Relax TF provider version requirements

### DIFF
--- a/asset-account/terraform/stack-set/.module.toml
+++ b/asset-account/terraform/stack-set/.module.toml
@@ -1,6 +1,6 @@
 [module]
 name    = "aws-elastio-asset-account-stack-set"
-version = "1.0.0"
+version = "1.1.0"
 
 description = "Terraform module for creating the Elastio Asset Account CloudFormation StackSet"
 type        = "terraform"

--- a/asset-account/terraform/stack-set/README.md
+++ b/asset-account/terraform/stack-set/README.md
@@ -29,13 +29,13 @@ module "elastio_asset_account" {
 | Name                                                                     | Version |
 | ------------------------------------------------------------------------ | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | ~> 1.9  |
-| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | ~> 5.0  |
+| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | >= 5.0  |
 
 ## Providers
 
 | Name                                             | Version |
 | ------------------------------------------------ | ------- |
-| <a name="provider_aws"></a> [aws](#provider_aws) | ~> 5.0  |
+| <a name="provider_aws"></a> [aws](#provider_aws) | >= 5.0  |
 
 ## Modules
 

--- a/asset-account/terraform/stack-set/README.md
+++ b/asset-account/terraform/stack-set/README.md
@@ -16,7 +16,7 @@ See the `examples` directory for some examples of how this module can be used:
 ```tf
 module "elastio_asset_account" {
   source  = "terraform.cloudsmith.io/public/elastio-asset-account-stack-set/aws"
-  version = "1.0.0"
+  version = "1.1.0"
 
   // Provide input parameters
 }

--- a/asset-account/terraform/stack-set/versions.tf
+++ b/asset-account/terraform/stack-set/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/codegen/src/iam.ts
+++ b/codegen/src/iam.ts
@@ -53,7 +53,7 @@ type Action =
 type KnownTag =
   // A simple tag that customers can add to their resource for Elastio to
   // get access to it. It's first use case at the time of this writing is
-  // autorizing Elastio access to KMS keys customers use to encrypt their data.
+  // authorizing Elastio access to KMS keys customers use to encrypt their data.
   //
   // This tag can currently be set to a value like an empty string or `true`.
   // However, we may reserve the right to endow special values for this tag

--- a/connector/terraform/modules/account/.module.toml
+++ b/connector/terraform/modules/account/.module.toml
@@ -1,5 +1,5 @@
 [module]
-name = "aws-elastio-connector-account"
 description = "Terraform module for creating the Elastio Connector Account stack"
-type = "terraform"
-version = "0.33.2"
+name        = "aws-elastio-connector-account"
+type        = "terraform"
+version     = "0.34.0"

--- a/connector/terraform/modules/account/README.md
+++ b/connector/terraform/modules/account/README.md
@@ -11,7 +11,7 @@ See the [`elastio-connector` module implementation](../../main.tf) for an exampl
 ```tf
 module "elastio_connector_account" {
   source  = "terraform.cloudsmith.io/public/elastio-conenctor-account/aws"
-  version = "0.33.2"
+  version = "0.34.0"
 
   // Provide input parameters
 }

--- a/connector/terraform/modules/account/README.md
+++ b/connector/terraform/modules/account/README.md
@@ -24,15 +24,15 @@ module "elastio_connector_account" {
 | Name                                                                     | Version |
 | ------------------------------------------------------------------------ | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | ~> 1.9  |
-| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | ~> 5.0  |
-| <a name="requirement_http"></a> [http](#requirement_http)                | ~> 3.0  |
+| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | >= 5.0  |
+| <a name="requirement_http"></a> [http](#requirement_http)                | >= 3.0  |
 
 ## Providers
 
 | Name                                                               | Version |
 | ------------------------------------------------------------------ | ------- |
-| <a name="provider_aws"></a> [aws](#provider_aws)                   | ~> 5.0  |
-| <a name="provider_http"></a> [http](#provider_http)                | ~> 3.0  |
+| <a name="provider_aws"></a> [aws](#provider_aws)                   | >= 5.0  |
+| <a name="provider_http"></a> [http](#provider_http)                | >= 3.0  |
 | <a name="provider_terraform"></a> [terraform](#provider_terraform) | n/a     |
 
 ## Modules

--- a/connector/terraform/modules/account/versions.tf
+++ b/connector/terraform/modules/account/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
     http = {
       source  = "hashicorp/http"
-      version = "~> 3.0"
+      version = ">= 3.0"
     }
   }
 }

--- a/connector/terraform/modules/nat-provision/.module.toml
+++ b/connector/terraform/modules/nat-provision/.module.toml
@@ -1,5 +1,5 @@
 [module]
-name = "aws-elastio-nat-provision"
 description = "Terraform module for creating the Elastio NAT Provision stack"
-type = "terraform"
-version = "0.33.2"
+name        = "aws-elastio-nat-provision"
+type        = "terraform"
+version     = "0.34.0"

--- a/connector/terraform/modules/nat-provision/README.md
+++ b/connector/terraform/modules/nat-provision/README.md
@@ -24,13 +24,13 @@ module "elastio_nat_provision" {
 | Name                                                                     | Version |
 | ------------------------------------------------------------------------ | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | ~> 1.9  |
-| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | ~> 5.0  |
+| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | >= 5.0  |
 
 ## Providers
 
 | Name                                             | Version |
 | ------------------------------------------------ | ------- |
-| <a name="provider_aws"></a> [aws](#provider_aws) | ~> 5.0  |
+| <a name="provider_aws"></a> [aws](#provider_aws) | >= 5.0  |
 
 ## Modules
 

--- a/connector/terraform/modules/nat-provision/README.md
+++ b/connector/terraform/modules/nat-provision/README.md
@@ -11,7 +11,7 @@ See the [`elastio-connector` module implementation](../../main.tf) for an exampl
 ```tf
 module "elastio_nat_provision" {
   source  = "terraform.cloudsmith.io/public/elastio-nat-provision/aws"
-  version = "0.33.2"
+  version = "0.34.0"
 
   // Provide input parameters
 }

--- a/connector/terraform/modules/nat-provision/versions.tf
+++ b/connector/terraform/modules/nat-provision/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/connector/terraform/modules/region/.module.toml
+++ b/connector/terraform/modules/region/.module.toml
@@ -1,5 +1,5 @@
 [module]
-name = "aws-elastio-connector-region"
 description = "Terraform module for creating the Elastio Connector Region stack"
-type = "terraform"
-version = "0.33.1"
+name        = "aws-elastio-connector-region"
+type        = "terraform"
+version     = "0.34.0"

--- a/connector/terraform/modules/region/README.md
+++ b/connector/terraform/modules/region/README.md
@@ -11,7 +11,7 @@ See the [`elastio-connector` module implementation](../../main.tf) for an exampl
 ```tf
 module "elastio_connector_region" {
   source  = "terraform.cloudsmith.io/public/elastio-connector-region/aws"
-  version = "0.33.1"
+  version = "0.34.0"
 
   // Provide input parameters
 }

--- a/connector/terraform/modules/region/README.md
+++ b/connector/terraform/modules/region/README.md
@@ -24,13 +24,13 @@ module "elastio_connector_region" {
 | Name                                                                     | Version |
 | ------------------------------------------------------------------------ | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | ~> 1.9  |
-| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | ~> 5.0  |
+| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | >= 5.0  |
 
 ## Providers
 
 | Name                                                               | Version |
 | ------------------------------------------------------------------ | ------- |
-| <a name="provider_aws"></a> [aws](#provider_aws)                   | ~> 5.0  |
+| <a name="provider_aws"></a> [aws](#provider_aws)                   | >= 5.0  |
 | <a name="provider_terraform"></a> [terraform](#provider_terraform) | n/a     |
 
 ## Modules

--- a/connector/terraform/modules/region/versions.tf
+++ b/connector/terraform/modules/region/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/iam-policies/terraform/.module.toml
+++ b/iam-policies/terraform/.module.toml
@@ -1,5 +1,5 @@
 [module]
-name = "aws-elastio-iam-policies"
 description = "A collection of AWS IAM policies for use with Elastio"
-type = "terraform"
-version = "0.33.3"
+name        = "aws-elastio-iam-policies"
+type        = "terraform"
+version     = "0.34.0"

--- a/iam-policies/terraform/README.md
+++ b/iam-policies/terraform/README.md
@@ -42,13 +42,13 @@ See the basic [usage example](./examples/basic/main.tf).
 | Name                                                                     | Version |
 | ------------------------------------------------------------------------ | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | ~> 1.9  |
-| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | ~> 5.0  |
+| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | >= 5.0  |
 
 ## Providers
 
 | Name                                             | Version |
 | ------------------------------------------------ | ------- |
-| <a name="provider_aws"></a> [aws](#provider_aws) | ~> 5.0  |
+| <a name="provider_aws"></a> [aws](#provider_aws) | >= 5.0  |
 
 ## Modules
 

--- a/iam-policies/terraform/README.md
+++ b/iam-policies/terraform/README.md
@@ -9,7 +9,7 @@ This Terraform module deploys additional Elastio IAM managed policies that you c
 ```tf
 module "elastio_policies" {
   source  = "terraform.cloudsmith.io/public/elastio-iam-policies/aws"
-  version = "0.33.3"
+  version = "0.34.0"
 
   // Provide input parameters
 }

--- a/iam-policies/terraform/versions.tf
+++ b/iam-policies/terraform/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/scripts/install-elastio.sh
+++ b/scripts/install-elastio.sh
@@ -31,7 +31,7 @@ cent7_amazon_install()
 {
     if [ ! -z "$driver" ]; then
         cent_fedora_kernel_devel_install $1
-        # Hack around zlib package updae on OL7 with versionlock in Oracle Cloud.
+        # Hack around zlib package update on OL7 with versionlock in Oracle Cloud.
         # dkms-elastio-snap depends on dkms. And dkms depends on zlib-1.2.7-21 which may be necessary to update.
         zlib_locked=0
         rpm -qa | grep -q versionlock && yum versionlock list | grep -q zlib && zlib_locked=1
@@ -113,7 +113,7 @@ deb_ubu_install()
         check_installed gnupg || apt-get install -y gnupg
     fi
 
-    # For Ubuntu 16.04 - 21.10 we are insatlling Debian packages:
+    # For Ubuntu 16.04 - 21.10 we are installing Debian packages:
     # Debian 9 for Ubuntu 18.XX, Debian 10 for Ubuntu 20.XX and 21.XX etc.
     # And Ubuntu 22.04 and newer have own repository.
     if [ "$dist_name" == "ubuntu" ] && [ "$dist_ver" -le 2110 ]; then


### PR DESCRIPTION
Stricter version requirements on providers cause more headacke than needed. Users often sit on various major versions of providers and forcing them to upgrade is often unnecessary. Relaxing the version requirements wildcards. We can reevaluate this if this causes any problems in the future